### PR TITLE
Support logs resource policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ rpCheckup uses the resources supported by [Endgame](https://endgame.readthedocs.
 | Resource Type                                  | rpCheckup | Endgame | [AWS Access Analyzer][1] |
 |------------------------------------------------|--------|---------|----------------------------------|
 | ACM Private CAs                | ✅   | ✅     | ❌                               |
-| CloudWatch Resource Policies      | 🔜   | ✅     |  ❌                              |
+| CloudWatch Resource Policies      | ✅   | ✅     |  ❌                              |
 | EBS Volume Snapshots               | ✅   | ✅     | ❌                               |
 | EC2 AMIs                          | ✅   | ✅     | ❌                               |
 | ECR Container Repositories         | ✅   | ✅     | ❌                               |

--- a/main.go
+++ b/main.go
@@ -153,6 +153,7 @@ var supportedResources resourceSpecMap = map[string][]string{
 	"es":             {"Domain"},
 	"ec2":            {"Images", "Snapshots"},
 	"lambda":         {"Alias", "Function", "LayerVersion"},
+	"logs":           {"LogGroup", "ResourcePolicies"},
 	"rds":            {"DBSnapshot", "DBClusterSnapshot"},
 	"s3":             {"Bucket"},
 	"secretsmanager": {"Secret"},


### PR DESCRIPTION
 Underlying introspector image supports them now, so we just need to import them to have them show up in the report.