### PR TITLE
Import Certificate Authorities

### DIFF
--- a/main.go
+++ b/main.go
@@ -143,6 +143,7 @@ func writeHTMLReport(rpReport *report.Report, outputFilename string) error {
 type resourceSpecMap = map[string][]string
 
 var supportedResources resourceSpecMap = map[string][]string{
+	"acm-pca":        {"CertificateAuthority"},
 	"iam":            {"role"},
 	"glacier":        {"Vault"},
 	"efs":            {"FileSystem"},

--- a/pkg/introspector/introspector.go
+++ b/pkg/introspector/introspector.go
@@ -15,7 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-const introspectorRef = "goldfig/introspector:v2"
+const introspectorRef = "goldfig/introspector:v2.1.1"
 const introspectorContainerName = "introspector"
 
 // Service is a wrapper around a docker container running


### PR DESCRIPTION
Now that introspector properly pulls in certificate authorities, we can properly import them as well.